### PR TITLE
key "scale" was missing from the image dictionary

### DIFF
--- a/pylsr/__init__.py
+++ b/pylsr/__init__.py
@@ -110,8 +110,8 @@ def read(filename: str) -> LSRImage:
 						LSRImageData(
 							Image.open(layerImage).convert("RGBA"),
 							image["filename"].replace(".png", ""),
-							image["scale"],
-							image["idiom"],
+							image.get("scale", "1x"),
+							image.get("idiom", "universal"),
 						)
 					)
 			lsrLayers.append(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

### What changes did you make? (Give an overview)
Instead of `image["scale"]` which can fail when there is not `"scale"` key in the `image` dictionary, put `image.get("scale", "1x")` which will return `"1x"` if there is not key `"scale"` in the dictionary.
Same fix is done for the key` "idiom"`, just to be safe.

### Which issue (if any) does this pull request address?
Fixes #3 

### Is there anything you'd like reviewers to focus on?
No, there is nothing else.